### PR TITLE
Escape all $(pwd) calls so folders with spaces dont break

### DIFF
--- a/1.make-libs.sh
+++ b/1.make-libs.sh
@@ -3,7 +3,7 @@
 set -e
 export NUM_THREAD=8
 
-cd $(pwd)/project
+cd "$(pwd)/project"
 source set_env.sh
 
 rm -rf zlib-1.2.8

--- a/2.make-apps.sh
+++ b/2.make-apps.sh
@@ -3,58 +3,58 @@
 set -e
 export NUM_THREAD=8
 
-cd $(pwd)/project
+cd "$(pwd)/project"
 source set_env.sh
 
 cd RetroArch
 make -j$NUM_THREAD -f Makefile.powkiddy
-cp retroarch $(pwd)/../../output/usr/bin
-cp gfx/video_filters/*.filt $(pwd)/../../output-sd/cfw/retroarch/filters/video/
+cp retroarch "$(pwd)/../../output/usr/bin"
+cp gfx/video_filters/*.filt "$(pwd)/../../output-sd/cfw/retroarch/filters/video/"
 cd ..
 
 cd DinguxCommander
 make -j$NUM_THREAD
-cp output/DinguxCommander $(pwd)/../../output-sd/cfw/apps/DinguxCommander
-cp res $(pwd)/../../output-sd/cfw/apps/DinguxCommander -rf
+cp output/DinguxCommander "$(pwd)/../../output-sd/cfw/apps/DinguxCommander"
+cp -rf res "$(pwd)/../../output-sd/cfw/apps/DinguxCommander"
 cd ..
 
 cd simplermenu_plus
 make -j$NUM_THREAD -f Makefile.powkiddy
-cp output/simplermenu_plus $(pwd)/../../output/usr/bin
+cp output/simplermenu_plus "$(pwd)/../../output/usr/bin"
 cd ..
 
 cd st-sdl
 make
-cp st $(pwd)/../../output-sd/cfw/apps/st
+cp st "$(pwd)/../../output-sd/cfw/apps/st"
 cd ..
 
 cd dac-analyser
 $CC -o dac_decoder reg_dac_analysis.c
-cp dac_decoder $(pwd)/../../output/usr/bin
+cp dac_decoder "$(pwd)/../../output/usr/bin"
 cd ..
 
 cd fbset
 make clean
 make -j$NUM_THREAD
-cp fbset $(pwd)/../../output/usr/bin
-cp modeline2fb $(pwd)/../../output/usr/bin
+cp fbset "$(pwd)/../../output/usr/bin"
+cp modeline2fb "$(pwd)/../../output/usr/bin"
 cd ..
 
 cd power_volume_handler
 $CC -o power_volume_handler power_volume_handler.c
-cp power_volume_handler $(pwd)/../../output/usr/bin
+cp power_volume_handler "$(pwd)/../../output/usr/bin"
 cd ..
 
 cd watchdog_feeder
 $CC -o watchdog_feeder watchdog_feeder.c
-cp watchdog_feeder $(pwd)/../../output/usr/bin
+cp watchdog_feeder "$(pwd)/../../output/usr/bin"
 cd ..
 
 rm -rf tinyalsa
 git clone -b v1.0.0 --depth 1 https://github.com/tinyalsa/tinyalsa.git
 cd tinyalsa
 make CROSS_COMPILE=$ARMABI-
-make install DESTDIR=$(pwd)/../../output/
+make install DESTDIR="$(pwd)/../../output/"
 
 rm -rf busybox
 git clone -b 1_36_1 --depth 1 https://github.com/mirror/busybox.git
@@ -72,7 +72,7 @@ cd strace
 ./bootstrap
 ./configure --host=arm-linux-gnueabihf --build=$(gcc -dumpmachine) 
 make -j$NUM_THREAD
-cp strace $(pwd)/../../output/usr/bin
+cp strace "$(pwd)/../../output/usr/bin"
 cd ..
 
 
@@ -81,5 +81,4 @@ cd ..
 #git submodule init
 #git submodule update
 #SDL_CONFIG=$SYSROOT/usr/local/bin/sdl-config ./configure --enable-neon --enable-threads --sound-drivers=sdl
-
 

--- a/3.libretro-core.sh
+++ b/3.libretro-core.sh
@@ -3,7 +3,7 @@
 set -e
 export NUM_THREAD=8
 
-cd $(pwd)/project
+cd "$(pwd)/project"
 source set_env.sh
 
 git clone https://github.com/libretro/libretro-super.git
@@ -97,10 +97,10 @@ wget -O /tmp/file.zip "https://buildbot.libretro.com/nightly/linux/armv7-neon-hf
 wget -O /tmp/file.zip "https://buildbot.libretro.com/nightly/linux/armv7-neon-hf/latest/tic80_libretro.so.zip" && unzip /tmp/file.zip -d dist/unix
 wget -O /tmp/file.zip "https://buildbot.libretro.com/nightly/linux/armv7-neon-hf/latest/vecx_libretro.so.zip" && unzip /tmp/file.zip -d dist/unix
 # all cores are stored on SD Card
-cp -rf dist/unix/* $(pwd)/../../output-sd/cfw/retroarch/cores/
+cp -rf dist/unix/* "$(pwd)/../../output-sd/cfw/retroarch/cores/"
 
 cd ..
 git clone https://github.com/schellingb/dosbox-pure.git
 cd dosbox-pure
 platform=classic_armv7_a7 make -j4
-cp  dosbox_pure_libretro.so $(pwd)/../../output-sd/cfw/retroarch/cores/
+cp dosbox_pure_libretro.so "$(pwd)/../../output-sd/cfw/retroarch/cores/"

--- a/4.builoutput.sh
+++ b/4.builoutput.sh
@@ -1,8 +1,8 @@
 #/bin/sh
 
-SYSROOT=$(pwd)/sysroot
-OUT=$(pwd)/output/
-TOOLCHAIN=$(pwd)/sysroot
+SYSROOT="$(pwd)/sysroot"
+OUT="$(pwd)/output/"
+TOOLCHAIN="$(pwd)/sysroot"
 
 mkdir -p $OUT/lib
 mkdir -p $OUT/usr/lib

--- a/project/set_env.sh
+++ b/project/set_env.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-export SYSROOT=$(pwd)/../sysroot
+export SYSROOT="$(pwd)/../sysroot"
 export CC="arm-linux-gnueabihf-gcc --sysroot=$SYSROOT"
 export CXX="arm-linux-gnueabihf-g++ --sysroot=$SYSROOT"
 export AR=arm-linux-gnueabihf-ar


### PR DESCRIPTION
The $(pwd) calls don't support folders (or user folders like /home/Bobby Bopper) with spaces. This prevents bash variable splitting.