### PR TITLE
Strip wasn't getting located correctly. also don't strip symlinks and…

### DIFF
--- a/4.buildoutput.sh
+++ b/4.buildoutput.sh
@@ -1,8 +1,21 @@
 #/bin/sh
 
-SYSROOT=$(pwd)/sysroot
-OUT=$(pwd)/output/
-TOOLCHAIN=$(pwd)/sysroot
+SYSROOT="$(pwd)/sysroot"
+OUT="$(pwd)/output/"
+TOOLCHAIN="$(pwd)/sysroot"
+STRIP_BIN="${TOOLCHAIN}/bin/arm-linux-gnueabihf-strip"
+READELF_BIN="${TOOLCHAIN}/bin/arm-linux-gnueabihf-readelf"
+
+strip_arm_elf_files() {
+	dir="$1"
+	shift
+
+	find "$dir" -type f | while IFS= read -r file; do
+		if "$READELF_BIN" -h "$file" 2>/dev/null | grep -q "Machine:.*ARM"; then
+			"$STRIP_BIN" "$@" "$file"
+		fi
+	done
+}
 
 mkdir -p $OUT/lib
 mkdir -p $OUT/usr/lib
@@ -41,7 +54,7 @@ find $OUT -name "*.la" -type f -delete
 
 find $OUT -name ".gitkeep" -type f -delete
 echo "=== cleaning done ==="
-arm-linux-gnueabihf-strip --strip-unneeded output/lib/*.so*
-arm-linux-gnueabihf-strip --strip-unneeded output/usr/lib/*.so*
-arm-linux-gnueabihf-strip output/usr/bin/*
+strip_arm_elf_files output/lib --strip-unneeded
+strip_arm_elf_files output/usr/lib --strip-unneeded
+strip_arm_elf_files output/usr/bin
 echo "=== finished ==="

--- a/6.strip-cores.sh
+++ b/6.strip-cores.sh
@@ -1,3 +1,17 @@
 #!/bin/sh
-arm-linux-gnueabihf-strip --strip-unneeded output-sd/cfw/lib/*.so*
-arm-linux-gnueabihf-strip --strip-unneeded output-sd/cfw/retroarch/cores/*.so*
+STRIP_BIN="$(pwd)/sysroot/bin/arm-linux-gnueabihf-strip"
+READELF_BIN="$(pwd)/sysroot/bin/arm-linux-gnueabihf-readelf"
+
+strip_arm_elf_files() {
+	dir="$1"
+	shift
+
+	find "$dir" -type f | while IFS= read -r file; do
+		if "$READELF_BIN" -h "$file" 2>/dev/null | grep -q "Machine:.*ARM"; then
+			"$STRIP_BIN" "$@" "$file"
+		fi
+	done
+}
+
+strip_arm_elf_files output-sd/cfw/lib --strip-unneeded
+strip_arm_elf_files output-sd/cfw/retroarch/cores --strip-unneeded


### PR DESCRIPTION
On Ubuntu 24.04, the arm-linaro strip wasn't getting found correctly. This locates it within the linaro toolchain.

The extra function is to prevent symlinks getting stripped.

Buil has been renamed to build (sh file name)