### PR TITLE
Enable compilation of boost by people not called Chris

### DIFF
--- a/1.make-libs.sh
+++ b/1.make-libs.sh
@@ -48,7 +48,7 @@ cd ..
 
 cd SDL-1.2
 chmod +x configure
-./configure --host=arm-linux-gnueabihf --disable-video-opengl --disable-video-x11 --enable-video-fbcon --disable-input-tslib --enable-joystick --enable-audio --enable-arm-simd --enable-arm-neon --build=$(gcc -dumpmachine) --enable-rpath=no
+./configure --host=arm-linux-gnueabihf --disable-video-opengl --disable-video-x11 --enable-video-fbcon --enable-joystick --enable-audio --enable-arm-simd --enable-arm-neon --build=$(gcc -dumpmachine) --enable-rpath=no
 make -j$NUM_THREAD
 make install DESTDIR=$SYSROOT
 #update pkg-config sdl because it's searching in rpath host libs...

--- a/1.make-libs.sh
+++ b/1.make-libs.sh
@@ -48,7 +48,7 @@ cd ..
 
 cd SDL-1.2
 chmod +x configure
-./configure --host=arm-linux-gnueabihf --disable-video-opengl --disable-video-x11 --enable-video-fbcon --enable-joystick --enable-audio --enable-arm-simd --enable-arm-neon --build=$(gcc -dumpmachine) --enable-rpath=no
+./configure --host=arm-linux-gnueabihf --disable-video-opengl --disable-video-x11 --enable-video-fbcon --disable-input-tslib --enable-joystick --enable-audio --enable-arm-simd --enable-arm-neon --build=$(gcc -dumpmachine) --enable-rpath=no
 make -j$NUM_THREAD
 make install DESTDIR=$SYSROOT
 #update pkg-config sdl because it's searching in rpath host libs...
@@ -108,11 +108,25 @@ git clone -b boost-1.87.0 --depth 1 https://github.com/boostorg/boost.git
 cd boost
 git submodule init
 git submodule update
-PATH=/usr/bin:/bin ./bootstrap.sh --with-libraries=filesystem,locale --with-toolset=gcc
-echo "using gcc : arm : /home/chris/powkiddy/sysroot/bin/arm-linux-gnueabihf-g++ ;" >> project-config.jam
-./b2 toolset=gcc-arm architecture=arm target-os=linux link=static      --with-filesystem --with-locale      cxxflags="-std=c++11 -march=armv7-a -mfpu=neon -mfloat-abi=hard --sysroot=/home/chris/powkiddy-X39-X45-X51-X70-cfw/sysroot"      stage
-./b2 headers
-./b2 toolset=gcc-arm architecture=arm target-os=linux link=static,shared --with-filesystem --with-locale cxxflags="-std=c++11 --sysroot=/home/chris/powkiddy-X39-X45-X51-X70-cfw/sysroot" --prefix=/home/chris/powkiddy-X39-X45-X51-X70-cfw/sysroot/usr install
+PATH=/usr/bin:/bin ./bootstrap.sh
+cat > project-config.jam <<EOF
+using gcc : arm : ${SYSROOT}/bin/arm-linux-gnueabihf-g++ ;
+EOF
+./b2 -j"$NUM_THREAD" \
+    toolset=gcc-arm \
+    install \
+    --prefix="${SYSROOT}/usr" \
+    architecture=arm \
+    target-os=linux \
+    link=static,shared \
+    --with-system \
+    --with-filesystem \
+    --with-date_time \
+    --with-locale \
+    cxxflags="-std=c++11 -march=armv7-a -mfpu=neon -mfloat-abi=hard --sysroot=${SYSROOT}" \
+    linkflags="--sysroot=${SYSROOT}" \
+    variant=release
+rsync -aL boost/ "${SYSROOT}/usr/include/boost/"
 
 cd ..
 rm -rf tiff-4.6.0
@@ -156,6 +170,6 @@ rm -rf libmad-0.15.1b
 wget https://downloads.sourceforge.net/mad/libmad-0.15.1b.tar.gz
 tar xf libmad-0.15.1b.tar.gz
 cd libmad-0.15.1b
-./configure --host=arm-linux-gnueabihf --build=$(gcc -dumpmachine)
-make -j$NUM_THREAD
+CFLAGS="${CFLAGS} -marm" ./configure --host=arm-linux-gnueabihf --build=$(gcc -dumpmachine)
+make -j$NUM_THREAD CFLAGS="${CFLAGS} -marm"
 make install DESTDIR=$SYSROOT


### PR DESCRIPTION
Boost was hard-coded to be compiled to sysroot `/home/chris/powkiddy/sysroot`. 

This commit:
- makes the sysroot dynamic 
- stages the headers using rsync to the sysroot
- switches libmad to arm mode so it doesn't use thumb asm.