### PR TITLE
fix missing tinyalsa build dependency (doxygen missing)

### DIFF
--- a/0.prepare.sh
+++ b/0.prepare.sh
@@ -13,6 +13,7 @@ sudo apt-get -y install \
 	cmake \
 	cmake-curses-gui \
 	cpio \
+	doxygen \
 	git \
 	libncurses5-dev \
 	locales \


### PR DESCRIPTION
tinyalsa can't build without doxygen. it looks like your wsl2 already had it installed.