### PR TITLE
flip tslib and sdl1 ordering so that sdl can link with it

### DIFF
--- a/1.make-libs.sh
+++ b/1.make-libs.sh
@@ -38,6 +38,15 @@ make -j$NUM_THREAD
 make install DESTDIR=$SYSROOT
 cd ..
 
+rm -rf tslib
+git clone https://github.com/libts/tslib.git
+cd tslib
+./autogen.sh
+./configure --host=arm-linux-gnueabihf --build=$(gcc -dumpmachine)
+make -j$NUM_THREAD
+make install DESTDIR=$SYSROOT
+cd ..
+
 rm -rf alsa-lib-1.2.9
 tar xvjf alsa-lib-1.2.9.tar.bz2
 cd alsa-lib-1.2.9
@@ -53,6 +62,9 @@ make -j$NUM_THREAD
 make install DESTDIR=$SYSROOT
 #update pkg-config sdl because it's searching in rpath host libs...
 sed -i 's|-Wl,-rpath,[^ ]*||; s|-lpthread|-lpthread -lasound|' $SYSROOT/usr/local/lib/pkgconfig/sdl.pc
+# Drop libtool archives before SDL_image links against SDL to avoid absolute
+# dependency paths like /usr/local/lib/libts.la leaking out of DESTDIR installs.
+find "$SYSROOT" -name "*.la" -delete
 cd ..
 
 rm -rf SDL_image-release-1.2.12
@@ -62,8 +74,6 @@ cd SDL_image-release-1.2.12
 make -j$NUM_THREAD
 make install DESTDIR=$SYSROOT
 cd ..
-
-find $SYSROOT -name "*.la" -delete
 
 rm -rf SDL_ttf
 git clone -b SDL-1.2 --depth 1 https://github.com/libsdl-org/SDL_ttf.git
@@ -139,15 +149,6 @@ wget https://storage.googleapis.com/downloads.webmproject.org/releases/webp/libw
 tar xf libwebp-1.2.4.tar.gz
 cd libwebp-1.2.4
 ./configure --host=arm-linux-gnueabihf --build=$(gcc -dumpmachine) --enable-neon
-make -j$NUM_THREAD
-make install DESTDIR=$SYSROOT
-cd ..
-
-rm -rf tslib
-git clone https://github.com/libts/tslib.git
-cd tslib
-./autogen.sh
-./configure --host=arm-linux-gnueabihf --build=$(gcc -dumpmachine)
 make -j$NUM_THREAD
 make install DESTDIR=$SYSROOT
 cd ..


### PR DESCRIPTION
```
dajoho@gmktek-k5:~/Projects/scooper540/powkiddy-X39-X45-X51-X70-cfw$ strings '/run/media/dajoho/efdbe1b2-64e4-437e-9b00-46e9a2c4ac49/usr/lib/libSDL-1.2.so.0.11.5' | grep "\.so"
libm.so.6
libts.so.0
libdl.so.2
libpthread.so.0
libc.so.6
libSDL-1.2.so.0
libasound.so.2`
```

in v1b your sdl1 .so is linked with libts, but libts is built AFTER sdl1 in build-libs, meaning libts only gets linked by chance on repeat builds. 

This commit flips the order and also moves the *.la deletion to before SDL_Image so it doesn't choke on the .la file.

Also `$SYSROOT` is now escaped so we have no bash variable splits on home folders containing spaces.