### PR TITLE
leave alsa directory before continuing to next package

### DIFF
--- a/2.make-apps.sh
+++ b/2.make-apps.sh
@@ -56,6 +56,7 @@ git clone -b v1.0.0 --depth 1 https://github.com/tinyalsa/tinyalsa.git
 cd tinyalsa
 make CROSS_COMPILE=$ARMABI-
 make install DESTDIR="$(pwd)/../../output/"
+cd ..
 
 rm -rf busybox
 git clone -b 1_36_1 --depth 1 https://github.com/mirror/busybox.git


### PR DESCRIPTION
The 2.build-apps won't continue after tinyalsa without leaving the folder first